### PR TITLE
Add CLI to generate TrackNet implementation plan and code stub

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,285 @@
+"""Utility script to outline and scaffold a TrackNet style project."""
+from __future__ import annotations
+
+import argparse
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List
+
+
+@dataclass
+class DataPlan:
+    """Suggestion for preparing the dataset."""
+
+    description: str
+    steps: List[str]
+
+    def render(self) -> str:
+        lines = ["数据准备建议:", f"  {self.description}", ""]
+        lines.extend(f"  - {step}" for step in self.steps)
+        return "\n".join(lines)
+
+
+@dataclass
+class ModelPlan:
+    """Suggestion for designing the neural network."""
+
+    backbone: str
+    decoder: str
+    loss_functions: List[str]
+
+    def render(self) -> str:
+        lines = [
+            "模型设计建议:",
+            f"  * 主干网络: {self.backbone}",
+            f"  * 解码器: {self.decoder}",
+            "  推荐损失函数:",
+        ]
+        lines.extend(f"    - {loss}" for loss in self.loss_functions)
+        return "\n".join(lines)
+
+
+@dataclass
+class TrainingPlan:
+    """Suggestion for training and evaluating the network."""
+
+    optimizer: str
+    scheduler: str
+    metrics: List[str]
+    augmentations: List[str]
+
+    def render(self) -> str:
+        lines = [
+            "训练与评估建议:",
+            f"  * 优化器: {self.optimizer}",
+            f"  * 学习率调度: {self.scheduler}",
+            "  关键指标:",
+        ]
+        lines.extend(f"    - {metric}" for metric in self.metrics)
+        lines.append("  数据增强:")
+        lines.extend(f"    - {aug}" for aug in self.augmentations)
+        return "\n".join(lines)
+
+
+@dataclass
+class CodeStub:
+    """Minimal code scaffold demonstrating TrackNet 核心结构."""
+
+    imports: str
+    dataset_class: str
+    model_class: str
+    train_function: str
+    evaluate_function: str
+
+    def render(self) -> str:
+        sections = [
+            self.imports.strip(),
+            self.dataset_class.strip(),
+            self.model_class.strip(),
+            self.train_function.strip(),
+            self.evaluate_function.strip(),
+        ]
+        return "\n\n\n".join(sections) + "\n"
+
+
+def build_plan() -> Dict[str, str]:
+    """Construct the recommendations for TrackNet implementation."""
+
+    data_plan = DataPlan(
+        description="为每个视频帧生成带高斯热力图的标签，同时保存原始帧与标注掩码。",
+        steps=[
+            "将视频拆分为逐帧图像，统一分辨率与帧率。",
+            "为球心坐标绘制二维高斯核，作为模型预测目标。",
+            "依据数据量划分训练/验证/测试集，保持时间连续性不被破坏。",
+            "使用 JSON 或 CSV 元数据记录文件路径与标注信息，便于自定义 Dataset。",
+        ],
+    )
+
+    model_plan = ModelPlan(
+        backbone="使用轻量化的编码器，例如 MobileNetV2 或 ResNet-18。",
+        decoder="采用多尺度反卷积/上采样以生成单通道热力图输出。",
+        loss_functions=[
+            "MSELoss: 对预测热力图与目标热力图进行像素级回归。",
+            "FocalLoss: 针对正负样本不平衡进行加权。",
+            "L1Loss: 作为附加监督以稳定训练。",
+        ],
+    )
+
+    training_plan = TrainingPlan(
+        optimizer="AdamW，初始学习率 1e-3，配合权重衰减。",
+        scheduler="CosineAnnealingLR 或 OneCycleLR，适配较长训练周期。",
+        metrics=[
+            "平均精度 (mAP) 在不同距离阈值下的表现。",
+            "像素级召回率与精确率，用于热力图质量评估。",
+            "球心回归误差（像素单位）。",
+        ],
+        augmentations=[
+            "随机旋转、平移与缩放，增强空间泛化能力。",
+            "色彩抖动以模拟不同光照条件。",
+            "基于时间轴的邻帧混合 (temporal mixing) 提高序列建模能力。",
+        ],
+    )
+
+    return {
+        "data": data_plan.render(),
+        "model": model_plan.render(),
+        "training": training_plan.render(),
+    }
+
+
+def build_code_stub() -> CodeStub:
+    """Create a ready-to-fill scaffold for TrackNet core modules."""
+
+    imports = textwrap.dedent(
+        """
+        import torch
+        from torch import nn
+        from torch.utils.data import Dataset, DataLoader
+
+        from typing import Dict, Tuple, List
+        """
+    )
+
+    dataset_class = textwrap.dedent(
+        """
+        class TrackNetDataset(Dataset):
+            \"\"\"示例数据集，需根据实际标注进行扩展。\"\"\"
+
+            def __init__(self, samples: List[Dict]):
+                self.samples = samples
+
+            def __len__(self) -> int:
+                return len(self.samples)
+
+            def __getitem__(self, idx: int):
+                sample = self.samples[idx]
+                frame = sample["frame"]  # 预处理后的图像张量
+                heatmap = sample["heatmap"]  # 对应的高斯热力图
+                return frame, heatmap
+        """
+    )
+
+    model_class = textwrap.dedent(
+        """
+        class TrackNet(nn.Module):
+            \"\"\"简化版 TrackNet，编码器-解码器结构。\"\"\"
+
+            def __init__(self, in_channels: int = 3):
+                super().__init__()
+                self.encoder = nn.Sequential(
+                    nn.Conv2d(in_channels, 32, kernel_size=3, padding=1),
+                    nn.BatchNorm2d(32),
+                    nn.ReLU(inplace=True),
+                    nn.MaxPool2d(2),
+                    nn.Conv2d(32, 64, kernel_size=3, padding=1),
+                    nn.BatchNorm2d(64),
+                    nn.ReLU(inplace=True),
+                    nn.MaxPool2d(2),
+                )
+                self.decoder = nn.Sequential(
+                    nn.ConvTranspose2d(64, 32, kernel_size=2, stride=2),
+                    nn.ReLU(inplace=True),
+                    nn.ConvTranspose2d(32, 16, kernel_size=2, stride=2),
+                    nn.ReLU(inplace=True),
+                    nn.Conv2d(16, 1, kernel_size=1),
+                    nn.Sigmoid(),
+                )
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                x = self.encoder(x)
+                x = self.decoder(x)
+                return x
+        """
+    )
+
+    train_function = textwrap.dedent(
+        """
+        def train(model: TrackNet, dataloader: DataLoader, *, device: torch.device, epochs: int = 10):
+            criterion = nn.MSELoss()
+            optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+            model.to(device)
+
+            for epoch in range(epochs):
+                model.train()
+                total_loss = 0.0
+                for frames, heatmaps in dataloader:
+                    frames = frames.to(device)
+                    heatmaps = heatmaps.to(device)
+                    optimizer.zero_grad()
+                    outputs = model(frames)
+                    loss = criterion(outputs, heatmaps)
+                    loss.backward()
+                    optimizer.step()
+                    total_loss += loss.item() * frames.size(0)
+                print(f"Epoch {epoch + 1}: loss={total_loss / len(dataloader.dataset):.4f}")
+        """
+    )
+
+    evaluate_function = textwrap.dedent(
+        """
+        def evaluate(model: TrackNet, dataloader: DataLoader, *, device: torch.device):
+            model.eval()
+            total_error = 0.0
+            with torch.no_grad():
+                for frames, heatmaps in dataloader:
+                    frames = frames.to(device)
+                    heatmaps = heatmaps.to(device)
+                    outputs = model(frames)
+                    total_error += nn.functional.l1_loss(outputs, heatmaps, reduction="sum").item()
+            print(f"Average L1 error: {total_error / len(dataloader.dataset):.4f}")
+        """
+    )
+
+    return CodeStub(
+        imports=imports,
+        dataset_class=dataset_class,
+        model_class=model_class,
+        train_function=train_function,
+        evaluate_function=evaluate_function,
+    )
+
+
+def export_stub(path: Path) -> None:
+    """Write the generated code skeleton to the given path."""
+
+    stub = build_code_stub().render()
+    path.write_text(stub, encoding="utf-8")
+
+
+def print_plan(plan: Dict[str, str]) -> None:
+    for section in ("data", "model", "training"):
+        print(plan[section])
+        print("\n" + "=" * 60 + "\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="TrackNet 实现建议与代码脚手架生成器")
+    parser.add_argument(
+        "--export",
+        type=Path,
+        help="将示例代码脚手架导出到指定 Python 文件。",
+    )
+    parser.add_argument(
+        "--plan-only",
+        action="store_true",
+        help="仅打印实现建议，不导出代码。",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    plan = build_plan()
+    print_plan(plan)
+
+    if not args.plan_only:
+        target_path = args.export or Path("tracknet_stub.py")
+        export_stub(target_path)
+        print(f"示例代码已写入: {target_path.resolve()}")
+
+    print("\n要根据实际项目进行扩展，可将上述脚手架整合到现有工程中。")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a CLI script that prints dataset, model, and training recommendations for a TrackNet implementation
- generate a customizable TrackNet code skeleton that can be optionally exported to a file
- outline core dataset, model, training, and evaluation scaffolding within the generated stub

## Testing
- python main.py --plan-only

------
https://chatgpt.com/codex/tasks/task_e_68d63d53ea808325b5c426acf153a250